### PR TITLE
Added crawl of in-progress projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.db
 *.db-shm
 *.db-wal
+index.html

--- a/itch_jam.py
+++ b/itch_jam.py
@@ -320,8 +320,11 @@ class ItchJamList:
             ):
                 self._list.append(ItchJam(id=jam[0]))
 
-    def _crawl_page(self, page=1):
-        base_url = "https://itch.io/jams/upcoming"
+    def _crawl_page(self, page=1, list="upcoming"):
+        if list == "upcoming":
+            base_url = "https://itch.io/jams/upcoming"
+        elif list == "in-progress":
+            base_url = "https://itch.io/jams/in-progress"
         req_payload = {"page": page}
 
         jams_flag = False
@@ -353,7 +356,12 @@ class ItchJamList:
         jam_ids = [item[0] for item in cur.fetchall()]
         cur.close()
 
-        while self._crawl_page(page):
+        page = 1
+        while self._crawl_page(page, list="in-progress"):
+            page = page + 1
+
+        page = 1
+        while self._crawl_page(page, list="upcoming"):
             page = page + 1
 
         with Progress(


### PR DESCRIPTION
Bug: if I did a crawl, then someone added a jam, then that jam started, then I did another crawl... I wouldn't catch the new jam because I only crawled future game jams. This is now fixed.

Fixes issue #5.
