### PR TITLE
Autoclassifier now handles digital games too

### DIFF
--- a/itch_jam.py
+++ b/itch_jam.py
@@ -1,6 +1,7 @@
 import json
 import re
 import sqlite3
+import tomllib
 from datetime import datetime, timedelta
 from enum import Enum
 from math import ceil
@@ -33,25 +34,6 @@ class ItchJam:
 
     db_conn = None
 
-    _tabletop_keywords = [
-        "analogici",
-        "analog game",
-        "analogue game",
-        "belonging outside belonging",
-        "fitd",
-        "gmless",
-        "megadungeon",
-        "osr",
-        "pamphlet",
-        "pbta",
-        "physical game",
-        "srd",
-        "sword dream",
-        "sworddream",
-        "system reference document",
-        "tabletop",
-        "ttrpg",
-    ]
     _itch_base_url = "https://itch.io"
 
     def __init__(
@@ -170,6 +152,9 @@ class ItchJam:
         return self.crawled
 
     def auto_classify(self):
+        with open("keywords.toml", "rb") as f:
+            keywords = tomllib.load(f)
+
         saved_jam_gametype = self.db_conn.execute(
             """
             SELECT json_each.value
@@ -181,9 +166,17 @@ class ItchJam:
         if saved_jam_gametype:
             self.gametype = GameType(saved_jam_gametype[0])
         elif any(
-            element in self.description.lower() for element in self._tabletop_keywords
+            element in self.description.lower()
+            for element in keywords["tabletop_keywords"]
         ):
             self.gametype = GameType.TABLETOP
+        elif any(
+            element in self.description.lower()
+            for element in keywords["digital_keywords"]
+        ) or any(
+            element in self.name.lower() for element in keywords["digital_keywords"]
+        ):
+            self.gametype = GameType.DIGITAL
 
         return self.gametype
 

--- a/itch_jam.py
+++ b/itch_jam.py
@@ -401,7 +401,7 @@ class ItchJamList:
                         case GameType.TABLETOP:
                             emoji = ":game_die: "
                         case GameType.DIGITAL:
-                            emoji = ""
+                            emoji = ":joystick:"
                     progress.console.print(
                         f"{emoji}{jam.name} <{jam.url()}>: {jam.gametype.name.lower()}"
                     )

--- a/keywords.toml
+++ b/keywords.toml
@@ -1,0 +1,26 @@
+tabletop_keywords = [
+        "analogici",
+        "analog game",
+        "analogue game",
+        "belonging outside belonging",
+        "fitd",
+        "gmless",
+        "megadungeon",
+        "osr",
+        "pamphlet",
+        "pbta",
+        "physical game",
+        "srd",
+        "sword dream",
+        "sworddream",
+        "system reference document",
+        "tabletop",
+        "ttrpg",
+]
+
+digital_keywords = [
+    "bitsy jam",
+    "trijam",
+    "zgd game jam",
+    "python game jam",
+]

--- a/keywords.toml
+++ b/keywords.toml
@@ -1,9 +1,10 @@
 tabletop_keywords = [
-        "analogici",
         "analog game",
+        "analogici",
         "analogue game",
         "belonging outside belonging",
         "fitd",
+        "gamebooks",
         "gmless",
         "megadungeon",
         "osr",
@@ -19,8 +20,19 @@ tabletop_keywords = [
 ]
 
 digital_keywords = [
+    "any engine",
     "bitsy jam",
-    "trijam",
-    "zgd game jam",
+    "game boy",
+    "fps",
+    "hyper game jam",
+    "ms-dos",
+    "playable on computers",
     "python game jam",
+    "rpg maker",
+    "shmup",
+    "source code",
+    "trijam",
+    "unity",
+    "unreal",
+    "zgd game jam",
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="itch_jam",
-    version="1.1",
+    version="1.2",
     py_modules=["itch_jam"],
     install_requires=[
         "bs4",


### PR DESCRIPTION
Added automatic classification for digital games. This runs after the tabletop classifier, so if a jam contains "TTRPG" and "shmup" it'll get classified as a tabletop game. This is a more liberal approach but I'd rather occasionally classify a digital game jam as tabletop than the other way around.

I also moved the keyword lists into a config file, and added an icon to indicate digital game classifications during the crawl. 

This is tested on a week's worth of jams and it looks OK so far.

Closes #13 